### PR TITLE
revision: change installation instructions to utilize an import map

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,34 +5,29 @@ Applura back end. It is only intended for browser use.
 
 ## Installation
 
-Add the following HTML element to the `<head>` of your project's `index.html`
+Add the following HTML elements to the `<head>` of your project's `index.html`
 file. Like so:
 
 ```html
-<script
-  async
-  rel="preload"
-  type="module"
-  src="https://cdn.applura.com/dist/js/client/v2.js"
-></script>
+<script type="importmap">{"imports":{"@applura/client":"https://cdn.applura.com/dist/js/client/v2.js"}}</script>
+<script async rel="preload" type="module" src="https://cdn.applura.com/dist/js/client/v2.js"></script>
 ```
 
-> Note: This CDN URL is the standard and supported way to import the client.
-> Applura does not publish an officially supported package for compile-time
-> import. [Learn more](#dynamic-vs-compile-time-import) about dynamic vs.
-> compile-time import.
+> Note: This CDN URL is the standard and only supported way to import the
+> client. Applura does not publish an officially supported package for
+> compile-time import. [Learn more](#browser-only-import) about browser-only
+> imports.
 
 ## Usage
 
 ### Starting the event loop
 
 Once the module is added to your HTML document's header element, you should
-import the client's `bootstrap` function. Usually, this import should be added
-to your project's `index.js` file. Like so:
+import the client's `bootstrap` function. Usually, this import will be added to
+your project's `index.js` file. Like so:
 
 ```javascript
-const ClientURL = "https://cdn.applura.com/dist/js/client/v2.js";
-const { bootstrap } = await import(ClientURL);
+import { bootstrap } from "@applura/client";
 ```
 
 Next, obtain a new client instance by calling the `bootstrap` function. Like so:
@@ -82,22 +77,22 @@ The `follow` function will fetch the target resource and send an event to your
 event loop when it has finished the fetch. After that fetch completes, you'll be
 able to update your application state using the new resource.
 
-> Note: `follow` returns a promise that only resolves to a boolean value
-> indicating whether the fetch succeeded. This functionality can be used to
-> display and hide loading animations.
+> Note: `follow` returns a promise that resolves to a boolean value indicating
+> whether the fetch succeeded. This functionality can be used to display and
+> hide loading animations.
 
-## Dynamic vs. compile-time import
+## Browser-only import
 
-Dynamically importing the client module from the Applura CDN is the standard and
+Importing the client module from the Applura CDN is the standard and only
 supported way to import the client module. Applura does not publish an
 officially supported package for compile-time import. Why?
 
 In short: so that we can deliver security, performance, and reliability
 improvements to our customers' applications in real-time.
 
-We will never intentionally publish an API breaking change to the same URL.
-Major version updates will only be published at new URLs so that your
-application never receives an unexpected update.
+We will never intentionally publish an API breaking change to the same URL. In
+other words, major version updates will only be published at new URLs so that
+your application never receives an unexpected update.
 
 The module source is published here under an open source license. We do not
 minify the production module nor do we remove comments. We do this so that it


### PR DESCRIPTION
This PR changes the installation instructions to utilize an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap). The previous instructions incorrectly suggested using a dynamic import, which delays processing and needless complicates import of the `bootstrap` function. Importing from `@applura/client` is also more aesthetically pleasing and opens the door to more local developer experience improvements.