### PR TITLE
fix: error when event.state is null, such as clicking an anchor #

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -96,12 +96,15 @@ export function bootstrap() {
   const client = new Client(initialURL.href);
   // Register a global listener for history updates.
   addEventListener("popstate", (event) => {
-    // Not navigating on a "back".
-    if ("url" in event.state) {
-      navigate = false;
-      client.follow(event.state.url, {}).finally(() => {
-        navigate = true;
-      });
+    // Not navigating without a state.
+    if (event.state) {
+      // Not navigating on a "back".
+      if ("url" in event.state) {
+        navigate = false;
+        client.follow(event.state.url, {}).finally(() => {
+          navigate = true;
+        });
+      }
     }
   });
   return client;


### PR DESCRIPTION
I noticed when clicking "anchor" links- to jump around the page- it was triggering the popstate event but `event.state` was null. This adds a check for state before attempting to find the url property.